### PR TITLE
Fix docs path handling in GUI

### DIFF
--- a/gui/src/main.py
+++ b/gui/src/main.py
@@ -11,9 +11,25 @@ from view.example.layout import layout as example_layout
 
 
 def load_doc(name: str) -> str | None:
-    doc_path = f"../../docs{name}.md"
+    """Load a markdown document from the ``docs`` folder.
+
+    Parameters
+    ----------
+    name:
+        The url path component requested by the user. It may start with
+        a leading ``/`` which will be stripped.
+    Returns
+    -------
+    str | None
+        The file contents if found, otherwise ``None``.
+    """
+
+    docs_dir = Path(__file__).resolve().parents[2] / "docs"
+    doc_path = docs_dir / f"{name.lstrip('/')}.md"
+
     if not doc_path.exists():
         return None
+
     text = doc_path.read_text(encoding="utf-8")
 
     if text.startswith("---"):


### PR DESCRIPTION
## Summary
- correctly build absolute path for docs
- document `load_doc` behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_686d5bb2dc00832bad34cd8fe12e3a65