### PR TITLE
Add site layout and styling

### DIFF
--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -1,4 +1,7 @@
 <nav class="navbar">
   <a href="index.html">Home</a> |
-  <a href="installation_and_usage.html">Installation and Usage</a>
+  <a href="installation_and_usage.html">Installation and Usage</a> |
+  <a href="https://github.com/danielamadori/PACO">
+    <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="github-logo">
+  </a>
 </nav>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ page.title }}</title>
+  <link rel="stylesheet" href="{{ '/style.css' | relative_url }}">
+</head>
+<body>
+  {{ content }}
+</body>
+</html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: Home
+layout: default
 ---
 
 <div class="page-wrapper">

--- a/docs/installation_and_usage.md
+++ b/docs/installation_and_usage.md
@@ -1,5 +1,6 @@
 ---
 title: Installation and Usage
+layout: default
 ---
 
 <div class="page-wrapper">

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.navbar {
+  background-color: #333;
+  padding: 10px;
+}
+
+.navbar a {
+  color: #fff;
+  text-decoration: none;
+  margin-right: 10px;
+}
+
+.github-logo {
+  height: 20px;
+  vertical-align: middle;
+}
+
+.page-wrapper {
+  margin-top: 20px;
+}
+
+.content {
+  margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- create a simple Jekyll layout for the documentation site
- add a small stylesheet for the navbar and page content
- enable the layout on `index.md` and `installation_and_usage.md`
- link to the GitHub repo from the navbar with a logo

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_686d5685f6d0832b8391e255db54752f