### PR TITLE
Fix docs stylesheet path

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>{{ page.title }}</title>
-  <link rel="stylesheet" href="{{ '/style.css' | relative_url }}">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   {{ content }}


### PR DESCRIPTION
## Summary
- update docs layout to use a relative stylesheet path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_686e7d3b7684832bb4daf9b123b8e3f9