### PR TITLE
Apply shared docs layout and refresh styling

### DIFF
--- a/docs/_includes/navbar.html
+++ b/docs/_includes/navbar.html
@@ -1,7 +1,10 @@
-<nav class="navbar">
-  <a href="index.html">Home</a> |
-  <a href="installation_and_usage.html">Installation and Usage</a> |
-  <a href="https://github.com/danielamadori/PACO">
-    <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub" class="github-logo">
-  </a>
+<nav class="navbar" role="navigation" aria-label="Main navigation">
+  <div class="navbar-brand">
+    <a class="navbar-home" href="{{ '/' | relative_url }}">PACO Docs</a>
+  </div>
+  <div class="navbar-links">
+    <a href="{{ '/' | relative_url }}">Home</a>
+    <a href="{{ '/installation_and_usage.html' | relative_url }}">Installation &amp; Usage</a>
+    <a class="navbar-cta" href="https://github.com/danielamadori/PACO">GitHub</a>
+  </div>
 </nav>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -1,16 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>{{ page.title }}</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body class="site-body">
-  <div class="page-wrapper">
-    {% include navbar.html %}
-    <main class="content-card">
-      {{ content }}
-    </main>
-  </div>
-</body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>
+      {{ page.title }}{% if site.title %} · {{ site.title }}{% endif %}
+    </title>
+    <link rel="stylesheet" href="{{ '/style.css' | relative_url }}">
+  </head>
+  <body class="site-body">
+    <div class="page-wrapper">
+      {% include navbar.html %}
+      <main class="content-card" role="main">
+        {{ content }}
+      </main>
+    </div>
+  </body>
 </html>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -5,7 +5,12 @@
   <title>{{ page.title }}</title>
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  {{ content }}
+<body class="site-body">
+  <div class="page-wrapper">
+    {% include navbar.html %}
+    <main class="content-card">
+      {{ content }}
+    </main>
+  </div>
 </body>
 </html>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,11 +3,6 @@ title: Home
 layout: default
 ---
 
-<div class="page-wrapper">
-{% include navbar.html %}
-
-<div class="content">
-
 ## A strategy founder for *BPMN + CPI*
 
 ## Features
@@ -23,7 +18,3 @@ In the context of increasingly complex business processes, accurately modeling d
 ### Solver
 RESPISE is an algorithm that given a *BPMN + CPI*  diagram and a bound impact vector can determine if there exists a feasible strategy such that the process can be completed while remaining under the bound vector. Moreover, We explain the synthesized strategies to users by labeling choice gateways in the BPMN diagram, making the strategies more interpretable and actionable.
 ![alt text](../image.png)
-
-
-</div>
-</div>

--- a/docs/installation_and_usage.md
+++ b/docs/installation_and_usage.md
@@ -3,11 +3,6 @@ title: Installation and Usage
 layout: default
 ---
 
-<div class="page-wrapper">
-{% include navbar.html %}
-
-<div class="content">
-
 # Installation and Usage
 
 ## Prerequisites
@@ -38,7 +33,7 @@ To start the application using Docker, follow these steps:
 2. Open a browser and navigate to `http://127.0.0.1:8050` to view the app.
 3. Open a browser and navigate to `http://127.0.0.1:8000` to access the application via REST API.
    The docs are available at `http://127.0.0.1:8000/docs`
-4. Open another browser tab and go to `http://127.0.0.1:8888` to access the Jupyter environment.  
+4. Open another browser tab and go to `http://127.0.0.1:8888` to access the Jupyter environment.
    You will find multiple `.ipynb` notebooks available — **we recommend [starting with `tutorial.ipynb`](https://nbviewer.org/github/danielamadori/PACO/blob/main/tutorial.ipynb)**, which provides a guided walkthrough of the main functionalities.
 
 ### Using Python
@@ -71,7 +66,7 @@ To start the application using Python, follow these steps:
     ```bash
     jupyter notebook --port=8888
     ```
-4. Open another browser tab and go to `http://127.0.0.1:8888` to access the Jupyter environment.  
+4. Open another browser tab and go to `http://127.0.0.1:8888` to access the Jupyter environment.
    You will find multiple `.ipynb` notebooks available — **we recommend [starting with `tutorial.ipynb`](https://nbviewer.org/github/danielamadori/PACO/blob/main/tutorial.ipynb)**, which provides a guided walkthrough of the main functionalities.
 
 ---
@@ -105,6 +100,3 @@ After execution, benchmark results and logs will be generated in the main direct
 
 - `benchmarks.sqlite` – Benchmark results database
 - `benchmarks_output.log` – Detailed benchmark execution log
-
-</div>
-</div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -7,6 +7,7 @@
   --accent-color: #2563eb;
   --accent-hover: #1d4ed8;
   --muted-color: #52606d;
+  --shadow-soft: 0 24px 50px rgba(15, 23, 42, 0.08);
 }
 
 * {
@@ -20,44 +21,72 @@ body.site-body {
   background: linear-gradient(180deg, var(--bg-start) 0%, var(--bg-end) 100%);
   color: var(--text-color);
   line-height: 1.6;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 32px 0;
 }
 
 .page-wrapper {
-  max-width: 900px;
-  margin: 40px auto;
-  padding: 0 24px;
+  width: min(920px, 100%);
+  margin: 48px 24px;
 }
 
 .navbar {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
-  margin-bottom: 24px;
-  padding: 16px 20px;
-  background-color: rgba(255, 255, 255, 0.8);
+  justify-content: space-between;
+  gap: 20px;
+  margin-bottom: 28px;
+  padding: 18px 24px;
+  background: rgba(255, 255, 255, 0.88);
   backdrop-filter: blur(6px);
   border: 1px solid rgba(37, 99, 235, 0.12);
-  border-radius: 14px;
-  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  border-radius: 18px;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
 }
 
-.navbar a {
-  color: var(--accent-color);
+.navbar-brand {
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.navbar-home {
+  color: var(--text-color);
   text-decoration: none;
+}
+
+.navbar-home:hover,
+.navbar-home:focus {
+  color: var(--accent-color);
+}
+
+.navbar-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+}
+
+.navbar-links a {
+  color: var(--accent-color);
   font-weight: 600;
-  transition: color 0.2s ease, text-shadow 0.2s ease;
+  text-decoration: none;
+  padding: 8px 14px;
+  border-radius: 999px;
+  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.navbar a:hover,
-.navbar a:focus {
-  color: var(--accent-hover);
-  text-shadow: 0 0 8px rgba(37, 99, 235, 0.25);
+.navbar-links a:hover,
+.navbar-links a:focus {
+  color: #fff;
+  background: var(--accent-color);
+  box-shadow: 0 12px 25px rgba(37, 99, 235, 0.3);
 }
 
-.github-logo {
-  height: 22px;
-  vertical-align: middle;
+.navbar-cta {
+  background: rgba(37, 99, 235, 0.1);
 }
 
 .content-card {
@@ -65,7 +94,7 @@ body.site-body {
   border: 1px solid var(--card-border);
   border-radius: 18px;
   padding: 36px;
-  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--shadow-soft);
 }
 
 .content-card h1,
@@ -83,9 +112,13 @@ body.site-body {
   margin-top: 0;
 }
 
+.content-card p,
+.content-card li {
+  color: var(--muted-color);
+}
+
 .content-card p {
   margin: 0 0 1.1em;
-  color: var(--muted-color);
   font-size: 1.02rem;
 }
 
@@ -93,7 +126,6 @@ body.site-body {
 .content-card ol {
   padding-left: 1.4em;
   margin: 0 0 1.2em;
-  color: var(--muted-color);
 }
 
 .content-card li + li {
@@ -118,16 +150,32 @@ body.site-body {
 }
 
 @media (max-width: 640px) {
-  .page-wrapper {
-    margin: 24px auto;
-    padding: 0 16px;
+  body.site-body {
+    padding: 0;
   }
 
-  .content-card {
-    padding: 24px;
+  .page-wrapper {
+    margin: 24px 16px;
   }
 
   .navbar {
-    padding: 14px 16px;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 16px;
+  }
+
+  .navbar-links {
+    width: 100%;
+    gap: 10px;
+  }
+
+  .navbar-links a {
+    flex: 1 1 auto;
+    text-align: center;
+  }
+
+  .content-card {
+    padding: 26px 22px;
   }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,30 +1,133 @@
-body {
-  font-family: Arial, sans-serif;
-  max-width: 800px;
-  margin: 0 auto;
-  padding: 20px;
+:root {
+  --bg-start: #f7f9fc;
+  --bg-end: #e2e8f0;
+  --card-bg: #ffffff;
+  --card-border: #d8dee6;
+  --text-color: #1f2933;
+  --accent-color: #2563eb;
+  --accent-hover: #1d4ed8;
+  --muted-color: #52606d;
 }
 
-.navbar {
-  background-color: #333;
-  padding: 10px;
+* {
+  box-sizing: border-box;
 }
 
-.navbar a {
-  color: #fff;
-  text-decoration: none;
-  margin-right: 10px;
-}
-
-.github-logo {
-  height: 20px;
-  vertical-align: middle;
+body.site-body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', 'Segoe UI', Roboto, Arial, sans-serif;
+  background: linear-gradient(180deg, var(--bg-start) 0%, var(--bg-end) 100%);
+  color: var(--text-color);
+  line-height: 1.6;
 }
 
 .page-wrapper {
-  margin-top: 20px;
+  max-width: 900px;
+  margin: 40px auto;
+  padding: 0 24px;
 }
 
-.content {
-  margin-top: 20px;
+.navbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 24px;
+  padding: 16px 20px;
+  background-color: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(6px);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  border-radius: 14px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.navbar a {
+  color: var(--accent-color);
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s ease, text-shadow 0.2s ease;
+}
+
+.navbar a:hover,
+.navbar a:focus {
+  color: var(--accent-hover);
+  text-shadow: 0 0 8px rgba(37, 99, 235, 0.25);
+}
+
+.github-logo {
+  height: 22px;
+  vertical-align: middle;
+}
+
+.content-card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 18px;
+  padding: 36px;
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.08);
+}
+
+.content-card h1,
+.content-card h2,
+.content-card h3,
+.content-card h4 {
+  color: var(--text-color);
+  margin-top: 1.8em;
+  margin-bottom: 0.6em;
+  font-weight: 700;
+}
+
+.content-card h1:first-child,
+.content-card h2:first-child {
+  margin-top: 0;
+}
+
+.content-card p {
+  margin: 0 0 1.1em;
+  color: var(--muted-color);
+  font-size: 1.02rem;
+}
+
+.content-card ul,
+.content-card ol {
+  padding-left: 1.4em;
+  margin: 0 0 1.2em;
+  color: var(--muted-color);
+}
+
+.content-card li + li {
+  margin-top: 0.35em;
+}
+
+.content-card code,
+.content-card pre {
+  font-family: 'Fira Code', 'Source Code Pro', Consolas, monospace;
+  background-color: #f1f5f9;
+  border-radius: 8px;
+}
+
+.content-card code {
+  padding: 2px 6px;
+  font-size: 0.95em;
+}
+
+.content-card pre {
+  padding: 16px;
+  overflow: auto;
+}
+
+@media (max-width: 640px) {
+  .page-wrapper {
+    margin: 24px auto;
+    padding: 0 16px;
+  }
+
+  .content-card {
+    padding: 24px;
+  }
+
+  .navbar {
+    padding: 14px 16px;
+  }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,13 +1,13 @@
 :root {
-  --bg-start: #f7f9fc;
-  --bg-end: #e2e8f0;
+  --bg-top: #f3f4f8;
+  --bg-bottom: #e2e8f0;
   --card-bg: #ffffff;
-  --card-border: #d8dee6;
+  --card-border: #d1d9e6;
   --text-color: #1f2933;
-  --accent-color: #2563eb;
-  --accent-hover: #1d4ed8;
-  --muted-color: #52606d;
-  --shadow-soft: 0 24px 50px rgba(15, 23, 42, 0.08);
+  --muted-text: #52606d;
+  --accent: #2563eb;
+  --accent-dark: #1d4ed8;
+  --shadow-soft: 0 18px 45px rgba(15, 23, 42, 0.08);
 }
 
 * {
@@ -17,19 +17,18 @@
 body.site-body {
   margin: 0;
   min-height: 100vh;
-  font-family: 'Inter', 'Segoe UI', Roboto, Arial, sans-serif;
-  background: linear-gradient(180deg, var(--bg-start) 0%, var(--bg-end) 100%);
+  font-family: "Inter", "Segoe UI", Roboto, Arial, sans-serif;
+  background: linear-gradient(180deg, var(--bg-top) 0%, var(--bg-bottom) 100%);
   color: var(--text-color);
-  line-height: 1.6;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  padding: 32px 0;
 }
 
 .page-wrapper {
-  width: min(920px, 100%);
-  margin: 48px 24px;
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 56px 24px 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
 }
 
 .navbar {
@@ -37,19 +36,18 @@ body.site-body {
   align-items: center;
   justify-content: space-between;
   gap: 20px;
-  margin-bottom: 28px;
-  padding: 18px 24px;
-  background: rgba(255, 255, 255, 0.88);
-  backdrop-filter: blur(6px);
+  padding: 18px 28px;
+  background: rgba(255, 255, 255, 0.9);
   border: 1px solid rgba(37, 99, 235, 0.12);
-  border-radius: 18px;
-  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+  border-radius: 20px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 16px 38px rgba(15, 23, 42, 0.08);
 }
 
 .navbar-brand {
   font-size: 1.05rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
+  letter-spacing: 0.01em;
 }
 
 .navbar-home {
@@ -57,112 +55,140 @@ body.site-body {
   text-decoration: none;
 }
 
-.navbar-home:hover,
-.navbar-home:focus {
-  color: var(--accent-color);
+.navbar-home:focus,
+.navbar-home:hover {
+  color: var(--accent);
 }
 
 .navbar-links {
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
-  gap: 16px;
+  flex-wrap: wrap;
+  gap: 14px;
 }
 
 .navbar-links a {
-  color: var(--accent-color);
+  color: var(--accent);
   font-weight: 600;
   text-decoration: none;
-  padding: 8px 14px;
+  padding: 8px 16px;
   border-radius: 999px;
-  transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
-.navbar-links a:hover,
-.navbar-links a:focus {
+.navbar-links a:focus,
+.navbar-links a:hover {
   color: #fff;
-  background: var(--accent-color);
-  box-shadow: 0 12px 25px rgba(37, 99, 235, 0.3);
+  background: var(--accent);
+  box-shadow: 0 12px 25px rgba(37, 99, 235, 0.35);
 }
 
 .navbar-cta {
-  background: rgba(37, 99, 235, 0.1);
+  background: rgba(37, 99, 235, 0.08);
 }
 
 .content-card {
-  background-color: var(--card-bg);
+  background: var(--card-bg);
   border: 1px solid var(--card-border);
-  border-radius: 18px;
-  padding: 36px;
+  border-radius: 22px;
+  padding: 42px 48px;
   box-shadow: var(--shadow-soft);
 }
 
 .content-card h1,
 .content-card h2,
 .content-card h3,
-.content-card h4 {
+.content-card h4,
+.content-card h5 {
   color: var(--text-color);
-  margin-top: 1.8em;
-  margin-bottom: 0.6em;
+  margin-top: 2.4rem;
+  margin-bottom: 1rem;
   font-weight: 700;
 }
 
 .content-card h1:first-child,
-.content-card h2:first-child {
+.content-card h2:first-child,
+.content-card h3:first-child {
   margin-top: 0;
 }
 
 .content-card p,
 .content-card li {
-  color: var(--muted-color);
+  color: var(--muted-text);
+  font-size: 1.02rem;
 }
 
 .content-card p {
-  margin: 0 0 1.1em;
-  font-size: 1.02rem;
+  margin: 0 0 1.2em;
 }
 
 .content-card ul,
 .content-card ol {
-  padding-left: 1.4em;
-  margin: 0 0 1.2em;
+  margin: 0 0 1.4em;
+  padding-left: 1.5em;
 }
 
 .content-card li + li {
   margin-top: 0.35em;
 }
 
-.content-card code,
-.content-card pre {
-  font-family: 'Fira Code', 'Source Code Pro', Consolas, monospace;
-  background-color: #f1f5f9;
-  border-radius: 8px;
+.content-card strong {
+  color: var(--text-color);
+}
+
+.content-card a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.content-card a:hover,
+.content-card a:focus {
+  color: var(--accent-dark);
+  text-decoration: underline;
 }
 
 .content-card code {
+  font-family: "Fira Code", "Source Code Pro", Consolas, monospace;
+  background-color: #f1f5f9;
+  border-radius: 6px;
   padding: 2px 6px;
   font-size: 0.95em;
 }
 
 .content-card pre {
-  padding: 16px;
-  overflow: auto;
+  font-family: "Fira Code", "Source Code Pro", Consolas, monospace;
+  background-color: #f1f5f9;
+  border-radius: 12px;
+  padding: 18px;
+  overflow-x: auto;
 }
 
-@media (max-width: 640px) {
-  body.site-body {
-    padding: 0;
-  }
+.content-card img {
+  max-width: 100%;
+  display: block;
+  margin: 24px auto;
+  border-radius: 14px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.08);
+}
 
+hr {
+  border: none;
+  border-top: 1px solid rgba(15, 23, 42, 0.1);
+  margin: 2.5rem 0;
+}
+
+@media (max-width: 768px) {
   .page-wrapper {
-    margin: 24px 16px;
+    padding: 32px 18px 48px;
+    gap: 24px;
   }
 
   .navbar {
     flex-direction: column;
     align-items: flex-start;
+    padding: 20px;
     gap: 12px;
-    padding: 16px;
   }
 
   .navbar-links {
@@ -176,6 +202,6 @@ body.site-body {
   }
 
   .content-card {
-    padding: 26px 22px;
+    padding: 28px 24px;
   }
 }


### PR DESCRIPTION
## Summary
- wrap documentation pages in a shared layout with navbar and card container
- refresh documentation styles with gradient background, card treatment, and refined typography
- remove manual wrappers from Markdown pages so they inherit the layout structure

## Testing
- bundle exec jekyll build *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_68dd73fa4de4832b90bf6543fcc24680