### PR TITLE
Wrap markdown docs in card

### DIFF
--- a/gui/src/main.py
+++ b/gui/src/main.py
@@ -29,7 +29,7 @@ def _discover_docs_dir() -> Path | None:
     return None
 
 
-def load_doc(name: str) -> dcc.Markdown | None:
+def load_doc(name: str) -> dbc.Card | None:
     logger.debug("load_doc called with name=%r", name)
     slug = name.strip("/")
     logger.debug("Normalized slug=%r", slug)
@@ -63,7 +63,8 @@ def load_doc(name: str) -> dcc.Markdown | None:
             text = parts[2]
 
     text = text.replace("{% include navbar.html %}", "")
-    return dcc.Markdown(text, dangerously_allow_html=True)
+    markdown = dcc.Markdown(text, dangerously_allow_html=True)
+    return dbc.Card(dbc.CardBody(markdown))
 
 
 app = dash.Dash(


### PR DESCRIPTION
## Summary
- wrap markdown documents loaded via `load_doc` in a Bootstrap card so they render within a consistent container

## Testing
- manual verification by running `PYTHONPATH=gui/src python gui/src/main.py` and visiting `/installation_and_usage`


------
https://chatgpt.com/codex/tasks/task_e_68dd7957a174832b8300e9cde53fc591