### PR TITLE
Fix relative imports for package execution

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -3,8 +3,8 @@ import subprocess
 import threading
 import signal
 import os
-from utils.env import LOG_TO_FILE, LOG_PATH
-from utils.logger import log_output, logger
+from .utils.env import LOG_TO_FILE, LOG_PATH
+from .utils.logger import log_output, logger
 
 
 gui_process = None

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from utils.env import LOG_TO_FILE, LOG_PATH
+from .env import LOG_TO_FILE, LOG_PATH
 
 
 def setup_logger(name: str, to_file: bool = False, filename: str = "logs/paco.log", level: str = "INFO") -> logging.Logger:


### PR DESCRIPTION
## Summary
- update the package launcher to use relative imports for environment and logger utilities
- align the logger helper to use relative imports so it resolves when the package is executed as a module

## Testing
- python -m src --gui

------
https://chatgpt.com/codex/tasks/task_e_68dd81ed84b4832b8617519abf2af867