### PR TITLE
Fix utils imports for module execution

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -3,8 +3,8 @@ import subprocess
 import threading
 import signal
 import os
-from utils.env import LOG_TO_FILE, LOG_PATH
-from utils.logger import log_output, logger
+from src.utils.env import LOG_TO_FILE, LOG_PATH
+from src.utils.logger import log_output, logger
 
 
 gui_process = None

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from utils.env import LOG_TO_FILE, LOG_PATH
+from .env import LOG_TO_FILE, LOG_PATH
 
 
 def setup_logger(name: str, to_file: bool = False, filename: str = "logs/paco.log", level: str = "INFO") -> logging.Logger:


### PR DESCRIPTION
## Summary
- update the logger utility to import environment constants using a package-relative path
- adjust __main__ imports to reference the src package so python -m src works without PYTHONPATH tweaks

## Testing
- python -m src --help

------
https://chatgpt.com/codex/tasks/task_e_68dd8569db84832b8d37cccc7cef49be