### PR TITLE
Add pm4py dependency for simulator integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ langchain-core~=0.3.35
 redis~=5.2.0
 requests~=2.32.3
 overrides>=7.4
+pm4py~=2.7.10


### PR DESCRIPTION
## Summary
- add pm4py~=2.7.10 to the project requirements so the simulator dependency is available

## Testing
- pip install -r requirements.txt *(fails: ProxyError prevents downloading pm4py)*
- python -m src --gui

------
https://chatgpt.com/codex/tasks/task_e_68dee6531518832b9e376375f072762e