### PR TITLE
Add full execution tree expansion algorithm to notebook

### DIFF
--- a/parallel_simulator_execution_tree.ipynb
+++ b/parallel_simulator_execution_tree.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Parallel execution tree expansion with the simulator API\n",
     "\n",
-    "Questo notebook mostra come usare le API REST del simulatore per generare un execution tree in parallelo. L'obiettivo è mantenere l'albero condiviso tra i thread, delegando la creazione dei nodi al simulatore e rispettando il vincolo che ogni thread che genera figli con una natura attiva continui immediatamente l'espansione di quella sottostruttura.\n"
+    "Questo notebook mostra come usare le API REST del simulatore per generare un execution tree in parallelo. L'obiettivo \u00e8 mantenere l'albero condiviso tra i thread, delegando la creazione dei nodi al simulatore e rispettando il vincolo che ogni thread che genera figli con una natura attiva continui immediatamente l'espansione di quella sottostruttura.\n"
    ],
    "id": "2f35f01d9b3e0ed4"
   },
@@ -27,6 +27,7 @@
     "import threading\n",
     "import queue\n",
     "import copy\n",
+    "from collections import deque\n",
     "from typing import Any, Dict, Iterable, List, Optional, Tuple\n",
     "import requests\n",
     "import graphviz\n",
@@ -321,8 +322,8 @@
     "            raise RuntimeError(f\"Worker error: {data['error']}\")\n",
     "        return data\n",
     "\n",
-    "    def bootstrap(self, parse_tree_dict: Dict[str, Any]) -> Dict[str, Any]:\n",
-    "        payload = {\"bpmn\": parse_tree_dict}\n",
+    "    def bootstrap(self, parse_tree_payload: Dict[str, Any]) -> Dict[str, Any]:\n",
+    "        payload = {\"bpmn\": parse_tree_payload}\n",
     "        return self.execute(payload)\n",
     "\n",
     "    def expand_node(\n",
@@ -371,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Utilità per navigare l'albero\n",
+    "## Utilit\u00e0 per navigare l'albero\n",
     "\n",
     "Funzioni di supporto per contare i nodi, estrarre percorsi e aggiornare porzioni dell'albero senza blocchi globali.\n"
    ],
@@ -525,8 +526,8 @@
     "            finally:\n",
     "                self._queue.task_done()\n",
     "\n",
-    "    def build(self, parse_tree_dict: Dict[str, Any]) -> Dict[str, Any]:\n",
-    "        bootstrap = self.client.bootstrap(parse_tree_dict)\n",
+    "    def build(self, parse_tree_payload: Dict[str, Any]) -> Dict[str, Any]:\n",
+    "        bootstrap = self.client.bootstrap(parse_tree_payload)\n",
     "        self._shared_tree = {\n",
     "            \"bpmn\": bootstrap[\"bpmn\"],\n",
     "            \"petri_net\": bootstrap[\"petri_net\"],\n",
@@ -554,6 +555,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Algoritmo di espansione completa\n",
+    "\n",
+    "Questo algoritmo espande ricorsivamente tutte le transizioni pendenti sfruttando le API del simulatore fino a saturare l'intero execution tree.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "def build_complete_execution_tree(client: SimulatorClient, parse_tree_payload: Dict[str, Any]) -> Dict[str, Any]:\n",
+    "    \"\"\"Espande completamente l'execution tree iterando sulle transizioni pendenti.\"\"\"\n",
+    "    shared_state = client.bootstrap(parse_tree_payload)\n",
+    "    frontier: deque[Tuple[str, ...]] = deque([()])\n",
+    "    while frontier:\n",
+    "        path = frontier.popleft()\n",
+    "        node = get_node_at_path(shared_state[\"execution_tree\"][\"root\"], path)\n",
+    "        if not (node.get(\"pending_choices\") or node.get(\"pending_natures\")):\n",
+    "            continue\n",
+    "        response = client.expand_node(shared_state, node[\"id\"])\n",
+    "        expanded_node = response[\"node\"]\n",
+    "        set_node_at_path(shared_state[\"execution_tree\"][\"root\"], path, expanded_node)\n",
+    "        for key in (\"bpmn\", \"petri_net\", \"petri_net_dot\", \"execution_tree\"):\n",
+    "            if key in response:\n",
+    "                shared_state[key] = response[key]\n",
+    "        updated_node = get_node_at_path(shared_state[\"execution_tree\"][\"root\"], path)\n",
+    "        if updated_node.get(\"pending_choices\") or updated_node.get(\"pending_natures\"):\n",
+    "            frontier.append(path)\n",
+    "        for transition_key, child in sorted(updated_node.get(\"transitions\", {}).items(), key=lambda item: str(item[0])):\n",
+    "            if child.get(\"pending_choices\") or child.get(\"pending_natures\"):\n",
+    "                frontier.append(path + (transition_key,))\n",
+    "    return shared_state\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Esecuzione della costruzione parallela\n",
     "\n",
     "L'esempio seguente utilizza quattro thread. Alla fine viene mostrato il numero totale di nodi generati.\n"
@@ -569,7 +609,9 @@
     }
    },
    "source": [
-    "parse_tree_dict = normalize_parse_tree(parse_tree)\n",
+    "parse_tree_payload = parse_tree\n",
+    "# Copia con tipi normalizzati per eventuali utility locali\n",
+    "parse_tree_dict = normalize_parse_tree(parse_tree_payload)\n",
     "impacts_names = bpmn_definition.get(IMPACTS_NAMES, [])\n",
     "\n"
    ],
@@ -589,10 +631,15 @@
     "client = SimulatorClient()\n",
     "builder = ParallelExecutionTreeBuilder(client, max_workers=4)\n",
     "\n",
-    "shared_state = builder.build(parse_tree_dict)\n",
-    "root_node = shared_state[\"execution_tree\"][\"root\"]\n",
-    "print(\"Numero totale di nodi generati:\", count_nodes(root_node))\n",
-    "execution_tree = shared_state[\"execution_tree\"]\n",
+    "shared_state_parallel = builder.build(parse_tree_payload)\n",
+    "parallel_root = shared_state_parallel[\"execution_tree\"][\"root\"]\n",
+    "print(\"Numero totale di nodi generati (parallelo):\", count_nodes(parallel_root))\n",
+    "\n",
+    "shared_state_complete = build_complete_execution_tree(client, parse_tree_payload)\n",
+    "complete_root = shared_state_complete[\"execution_tree\"][\"root\"]\n",
+    "print(\"Numero totale di nodi generati (algoritmo completo):\", count_nodes(complete_root))\n",
+    "\n",
+    "execution_tree = shared_state_complete[\"execution_tree\"]\n",
     "current_node_id = execution_tree.get(\"current_node\")\n",
     "converted_root = clone_with_children(execution_tree.get(\"root\", {}))\n",
     "highlight_path = get_path_to_current_node(converted_root, current_node_id) or []\n",
@@ -607,14 +654,14 @@
      "evalue": "422 Client Error: Unprocessable Entity for url: http://127.0.0.1:8001/execute",
      "output_type": "error",
      "traceback": [
-      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
-      "\u001B[0;31mHTTPError\u001B[0m                                 Traceback (most recent call last)",
-      "Cell \u001B[0;32mIn[13], line 4\u001B[0m\n\u001B[1;32m      1\u001B[0m client \u001B[38;5;241m=\u001B[39m SimulatorClient()\n\u001B[1;32m      2\u001B[0m builder \u001B[38;5;241m=\u001B[39m ParallelExecutionTreeBuilder(client, max_workers\u001B[38;5;241m=\u001B[39m\u001B[38;5;241m4\u001B[39m)\n\u001B[0;32m----> 4\u001B[0m shared_state \u001B[38;5;241m=\u001B[39m \u001B[43mbuilder\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mbuild\u001B[49m\u001B[43m(\u001B[49m\u001B[43mparse_tree_dict\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m      5\u001B[0m root_node \u001B[38;5;241m=\u001B[39m shared_state[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mexecution_tree\u001B[39m\u001B[38;5;124m\"\u001B[39m][\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mroot\u001B[39m\u001B[38;5;124m\"\u001B[39m]\n\u001B[1;32m      6\u001B[0m \u001B[38;5;28mprint\u001B[39m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mNumero totale di nodi generati:\u001B[39m\u001B[38;5;124m\"\u001B[39m, count_nodes(root_node))\n",
-      "Cell \u001B[0;32mIn[11], line 68\u001B[0m, in \u001B[0;36mParallelExecutionTreeBuilder.build\u001B[0;34m(self, parse_tree_dict)\u001B[0m\n\u001B[1;32m     67\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[38;5;21mbuild\u001B[39m(\u001B[38;5;28mself\u001B[39m, parse_tree_dict: Dict[\u001B[38;5;28mstr\u001B[39m, Any]) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m Dict[\u001B[38;5;28mstr\u001B[39m, Any]:\n\u001B[0;32m---> 68\u001B[0m     bootstrap \u001B[38;5;241m=\u001B[39m \u001B[38;5;28;43mself\u001B[39;49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mclient\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mbootstrap\u001B[49m\u001B[43m(\u001B[49m\u001B[43mparse_tree_dict\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m     69\u001B[0m     \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39m_shared_tree \u001B[38;5;241m=\u001B[39m {\n\u001B[1;32m     70\u001B[0m         \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mbpmn\u001B[39m\u001B[38;5;124m\"\u001B[39m: bootstrap[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mbpmn\u001B[39m\u001B[38;5;124m\"\u001B[39m],\n\u001B[1;32m     71\u001B[0m         \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpetri_net\u001B[39m\u001B[38;5;124m\"\u001B[39m: bootstrap[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpetri_net\u001B[39m\u001B[38;5;124m\"\u001B[39m],\n\u001B[1;32m     72\u001B[0m         \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpetri_net_dot\u001B[39m\u001B[38;5;124m\"\u001B[39m: bootstrap[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpetri_net_dot\u001B[39m\u001B[38;5;124m\"\u001B[39m],\n\u001B[1;32m     73\u001B[0m         \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mexecution_tree\u001B[39m\u001B[38;5;124m\"\u001B[39m: bootstrap[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mexecution_tree\u001B[39m\u001B[38;5;124m\"\u001B[39m],\n\u001B[1;32m     74\u001B[0m     }\n\u001B[1;32m     75\u001B[0m     \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39m_enqueue_initial_frontier(\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39m_shared_tree[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mexecution_tree\u001B[39m\u001B[38;5;124m\"\u001B[39m][\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mroot\u001B[39m\u001B[38;5;124m\"\u001B[39m])\n",
-      "Cell \u001B[0;32mIn[8], line 16\u001B[0m, in \u001B[0;36mWorker.bootstrap\u001B[0;34m(self, parse_tree_dict)\u001B[0m\n\u001B[1;32m     14\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[38;5;21mbootstrap\u001B[39m(\u001B[38;5;28mself\u001B[39m, parse_tree_dict: Dict[\u001B[38;5;28mstr\u001B[39m, Any]) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m Dict[\u001B[38;5;28mstr\u001B[39m, Any]:\n\u001B[1;32m     15\u001B[0m     payload \u001B[38;5;241m=\u001B[39m {\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mbpmn\u001B[39m\u001B[38;5;124m\"\u001B[39m: parse_tree_dict}\n\u001B[0;32m---> 16\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[38;5;28;43mself\u001B[39;49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mexecute\u001B[49m\u001B[43m(\u001B[49m\u001B[43mpayload\u001B[49m\u001B[43m)\u001B[49m\n",
-      "Cell \u001B[0;32mIn[8], line 8\u001B[0m, in \u001B[0;36mWorker.execute\u001B[0;34m(self, payload)\u001B[0m\n\u001B[1;32m      6\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m\u001B[38;5;250m \u001B[39m\u001B[38;5;21mexecute\u001B[39m(\u001B[38;5;28mself\u001B[39m, payload: Dict[\u001B[38;5;28mstr\u001B[39m, Any]) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m Dict[\u001B[38;5;28mstr\u001B[39m, Any]:\n\u001B[1;32m      7\u001B[0m     response \u001B[38;5;241m=\u001B[39m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39msession\u001B[38;5;241m.\u001B[39mpost(\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mbase_url \u001B[38;5;241m+\u001B[39m \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mexecute\u001B[39m\u001B[38;5;124m\"\u001B[39m, headers\u001B[38;5;241m=\u001B[39mHEADERS, json\u001B[38;5;241m=\u001B[39mpayload, timeout\u001B[38;5;241m=\u001B[39m\u001B[38;5;241m60\u001B[39m)\n\u001B[0;32m----> 8\u001B[0m     \u001B[43mresponse\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mraise_for_status\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m      9\u001B[0m     data \u001B[38;5;241m=\u001B[39m response\u001B[38;5;241m.\u001B[39mjson()\n\u001B[1;32m     10\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;124m\"\u001B[39m\u001B[38;5;124merror\u001B[39m\u001B[38;5;124m\"\u001B[39m \u001B[38;5;129;01min\u001B[39;00m data:\n",
-      "File \u001B[0;32m~/Projects/PACO/.venv/lib/python3.12/site-packages/requests/models.py:1026\u001B[0m, in \u001B[0;36mResponse.raise_for_status\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m   1021\u001B[0m     http_error_msg \u001B[38;5;241m=\u001B[39m (\n\u001B[1;32m   1022\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;132;01m{\u001B[39;00m\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mstatus_code\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m Server Error: \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mreason\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m for url: \u001B[39m\u001B[38;5;132;01m{\u001B[39;00m\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39murl\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m\"\u001B[39m\n\u001B[1;32m   1023\u001B[0m     )\n\u001B[1;32m   1025\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m http_error_msg:\n\u001B[0;32m-> 1026\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m HTTPError(http_error_msg, response\u001B[38;5;241m=\u001B[39m\u001B[38;5;28mself\u001B[39m)\n",
-      "\u001B[0;31mHTTPError\u001B[0m: 422 Client Error: Unprocessable Entity for url: http://127.0.0.1:8001/execute"
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mHTTPError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[13], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m client \u001b[38;5;241m=\u001b[39m SimulatorClient()\n\u001b[1;32m      2\u001b[0m builder \u001b[38;5;241m=\u001b[39m ParallelExecutionTreeBuilder(client, max_workers\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m4\u001b[39m)\n\u001b[0;32m----> 4\u001b[0m shared_state \u001b[38;5;241m=\u001b[39m \u001b[43mbuilder\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbuild\u001b[49m\u001b[43m(\u001b[49m\u001b[43mparse_tree_dict\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      5\u001b[0m root_node \u001b[38;5;241m=\u001b[39m shared_state[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexecution_tree\u001b[39m\u001b[38;5;124m\"\u001b[39m][\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mroot\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28mprint\u001b[39m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mNumero totale di nodi generati:\u001b[39m\u001b[38;5;124m\"\u001b[39m, count_nodes(root_node))\n",
+      "Cell \u001b[0;32mIn[11], line 68\u001b[0m, in \u001b[0;36mParallelExecutionTreeBuilder.build\u001b[0;34m(self, parse_tree_dict)\u001b[0m\n\u001b[1;32m     67\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mbuild\u001b[39m(\u001b[38;5;28mself\u001b[39m, parse_tree_dict: Dict[\u001b[38;5;28mstr\u001b[39m, Any]) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Dict[\u001b[38;5;28mstr\u001b[39m, Any]:\n\u001b[0;32m---> 68\u001b[0m     bootstrap \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mclient\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mbootstrap\u001b[49m\u001b[43m(\u001b[49m\u001b[43mparse_tree_dict\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     69\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_shared_tree \u001b[38;5;241m=\u001b[39m {\n\u001b[1;32m     70\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbpmn\u001b[39m\u001b[38;5;124m\"\u001b[39m: bootstrap[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbpmn\u001b[39m\u001b[38;5;124m\"\u001b[39m],\n\u001b[1;32m     71\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpetri_net\u001b[39m\u001b[38;5;124m\"\u001b[39m: bootstrap[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpetri_net\u001b[39m\u001b[38;5;124m\"\u001b[39m],\n\u001b[1;32m     72\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpetri_net_dot\u001b[39m\u001b[38;5;124m\"\u001b[39m: bootstrap[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mpetri_net_dot\u001b[39m\u001b[38;5;124m\"\u001b[39m],\n\u001b[1;32m     73\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexecution_tree\u001b[39m\u001b[38;5;124m\"\u001b[39m: bootstrap[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexecution_tree\u001b[39m\u001b[38;5;124m\"\u001b[39m],\n\u001b[1;32m     74\u001b[0m     }\n\u001b[1;32m     75\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_enqueue_initial_frontier(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_shared_tree[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexecution_tree\u001b[39m\u001b[38;5;124m\"\u001b[39m][\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mroot\u001b[39m\u001b[38;5;124m\"\u001b[39m])\n",
+      "Cell \u001b[0;32mIn[8], line 16\u001b[0m, in \u001b[0;36mWorker.bootstrap\u001b[0;34m(self, parse_tree_dict)\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mbootstrap\u001b[39m(\u001b[38;5;28mself\u001b[39m, parse_tree_dict: Dict[\u001b[38;5;28mstr\u001b[39m, Any]) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Dict[\u001b[38;5;28mstr\u001b[39m, Any]:\n\u001b[1;32m     15\u001b[0m     payload \u001b[38;5;241m=\u001b[39m {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mbpmn\u001b[39m\u001b[38;5;124m\"\u001b[39m: parse_tree_dict}\n\u001b[0;32m---> 16\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mexecute\u001b[49m\u001b[43m(\u001b[49m\u001b[43mpayload\u001b[49m\u001b[43m)\u001b[49m\n",
+      "Cell \u001b[0;32mIn[8], line 8\u001b[0m, in \u001b[0;36mWorker.execute\u001b[0;34m(self, payload)\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mexecute\u001b[39m(\u001b[38;5;28mself\u001b[39m, payload: Dict[\u001b[38;5;28mstr\u001b[39m, Any]) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Dict[\u001b[38;5;28mstr\u001b[39m, Any]:\n\u001b[1;32m      7\u001b[0m     response \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39msession\u001b[38;5;241m.\u001b[39mpost(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mbase_url \u001b[38;5;241m+\u001b[39m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mexecute\u001b[39m\u001b[38;5;124m\"\u001b[39m, headers\u001b[38;5;241m=\u001b[39mHEADERS, json\u001b[38;5;241m=\u001b[39mpayload, timeout\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m60\u001b[39m)\n\u001b[0;32m----> 8\u001b[0m     \u001b[43mresponse\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mraise_for_status\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      9\u001b[0m     data \u001b[38;5;241m=\u001b[39m response\u001b[38;5;241m.\u001b[39mjson()\n\u001b[1;32m     10\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124merror\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m data:\n",
+      "File \u001b[0;32m~/Projects/PACO/.venv/lib/python3.12/site-packages/requests/models.py:1026\u001b[0m, in \u001b[0;36mResponse.raise_for_status\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1021\u001b[0m     http_error_msg \u001b[38;5;241m=\u001b[39m (\n\u001b[1;32m   1022\u001b[0m         \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mstatus_code\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m Server Error: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mreason\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m for url: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39murl\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m   1023\u001b[0m     )\n\u001b[1;32m   1025\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m http_error_msg:\n\u001b[0;32m-> 1026\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m HTTPError(http_error_msg, response\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m)\n",
+      "\u001b[0;31mHTTPError\u001b[0m: 422 Client Error: Unprocessable Entity for url: http://127.0.0.1:8001/execute"
      ]
     }
    ],


### PR DESCRIPTION
## Summary
- import deque support and document the complete expansion workflow in the parallel simulator notebook
- add a `build_complete_execution_tree` helper that iteratively expands all pending branches via the simulator API
- ensure the full expansion helper patches simulator responses back into the shared execution tree so every branch materializes correctly
- update the demo cell to compare the parallel builder with the full expansion algorithm and reuse the resulting tree for visualization

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df003b6e40832b9ab534a0107750ee