### PR TITLE
Ensure execute_decisions forwards Petri net DOT

### DIFF
--- a/gui/src/controller/home/sidebar/simulator_tab/pending_decisions.py
+++ b/gui/src/controller/home/sidebar/simulator_tab/pending_decisions.py
@@ -15,7 +15,14 @@ def register_pending_decision_callbacks(callback):
         prevent_initial_call=False,
     )
     def populate_pending_decisions(simulator_data):
-        return update_pending_decisions(simulator_data["gateway_decisions"])
+        if not simulator_data:
+            return []
+
+        gateway_decisions = simulator_data.get("gateway_decisions") or {}
+        if not gateway_decisions:
+            return []
+
+        return update_pending_decisions(gateway_decisions)
 
     @callback(
         Output({"type": "gateway", "id": ALL}, "value"),
@@ -27,6 +34,9 @@ def register_pending_decision_callbacks(callback):
     )
     def update_random_decisions(individual_clicks, global_click, gateway_ids, sim_data):
         triggered = ctx.triggered_id
+        if not sim_data or not sim_data.get("gateway_decisions"):
+            return [no_update] * len(gateway_ids or [])
+
         result = []
 
         for i, gw_obj in enumerate(gateway_ids):

--- a/gui/src/controller/home/sidebar/simulator_tab/pending_decisions.py
+++ b/gui/src/controller/home/sidebar/simulator_tab/pending_decisions.py
@@ -11,18 +11,19 @@ from gui.src.view.home.sidebar.simulator_tab.pending_decisions import (
 def register_pending_decision_callbacks(callback):
     @callback(
         Output("pending-decisions-body", "children"),
+        Output("pending-decisions-card-container", "style"),
         Input("simulation-store", "data"),
         prevent_initial_call=False,
     )
     def populate_pending_decisions(simulator_data):
         if not simulator_data:
-            return []
+            return [], {"display": "none"}
 
         gateway_decisions = simulator_data.get("gateway_decisions") or {}
         if not gateway_decisions:
-            return []
+            return [], {"display": "none"}
 
-        return update_pending_decisions(gateway_decisions)
+        return update_pending_decisions(gateway_decisions), {}
 
     @callback(
         Output({"type": "gateway", "id": ALL}, "value"),

--- a/gui/src/model/etl.py
+++ b/gui/src/model/etl.py
@@ -407,13 +407,14 @@ def execute_decisions(bpmn, gateway_decisions: list[str], step: int | None = Non
     try:
         bpmn = keep_relevant_bpmn(bpmn)
         parse_tree = load_parse_tree(bpmn)
-        petri_net, *_ = get_petri_net(bpmn, step)
+        petri_net, petri_net_dot = get_petri_net(bpmn, step)
         execution_tree, current_execution = load_execution_tree(bpmn)
         decisions = list(gateway_decisions)
 
         request = {
             "bpmn": parse_tree,
             "petri_net": petri_net,
+            "petri_net_dot": petri_net_dot,
             "execution_tree": {"root": execution_tree, "current_node": current_execution},
             "choices": decisions,
         }

--- a/gui/src/model/sqlite.py
+++ b/gui/src/model/sqlite.py
@@ -77,18 +77,20 @@ def update_bpmn_dot(bpmn_dict:dict, bpmn_dot:str):
 def save_execution_tree(bpmn_dict: dict, execution_tree: str, actual_execution: str):
     bpmn_str = json.dumps(bpmn_dict, sort_keys=True)
     record = BPMN.get(bpmn=bpmn_str)
-    if record:
-        record.execution_tree = execution_tree or ""
-        record.actual_execution = actual_execution or ""
-        commit()
+    if not record:
+        record = BPMN(bpmn=bpmn_str)
+    record.execution_tree = execution_tree or ""
+    record.actual_execution = actual_execution or ""
+    commit()
 
 @db_session
 def save_parse_tree(bpmn_dict:dict, parse_tree:str):
     bpmn_str = json.dumps(bpmn_dict, sort_keys=True)
     record = BPMN.get(bpmn=bpmn_str)
-    if record:
-        record.parse_tree = parse_tree or ""
-        commit()
+    if not record:
+        record = BPMN(bpmn=bpmn_str)
+    record.parse_tree = parse_tree or ""
+    commit()
 
 
 @db_session
@@ -129,10 +131,11 @@ def save_strategy(bpmn_dict: dict, bound_list: list, result:str, expected_impact
 def save_petri_net(bpmn_dict:dict, petri_net:str, petri_net_dot:str):
     bpmn_str = json.dumps(bpmn_dict, sort_keys=True)
     record = BPMN.get(bpmn=bpmn_str)
-    if record:
-        record.petri_net = petri_net or ""
-        record.petri_net_dot = petri_net_dot or ""
-        commit()
+    if not record:
+        record = BPMN(bpmn=bpmn_str)
+    record.petri_net = petri_net or ""
+    record.petri_net_dot = petri_net_dot or ""
+    commit()
 
 
 @db_session

--- a/gui/src/view/home/sidebar/simulator_tab/pending_decisions.py
+++ b/gui/src/view/home/sidebar/simulator_tab/pending_decisions.py
@@ -3,31 +3,35 @@ from dash import html, dcc
 
 
 def get_pending_decisions():
-    return dbc.Card([
-        dbc.CardHeader(
-            html.Div([
-                html.H5("Pending Decisions", style={"margin": 0}),
-                dbc.Button("Random", id="global-random", color="secondary", size="sm")
-            ], style={
-                "display": "flex",
-                "justifyContent": "space-between",
-                "alignItems": "center"
-            })
-        ),
-        dbc.CardBody(
-            html.Div(
-                id="pending-decisions-body",
-                style={
-                    "maxHeight": "200px",
-                    "overflowY": "auto",
-                    "padding": "5px"
-                }
+    return html.Div(
+        dbc.Card([
+            dbc.CardHeader(
+                html.Div([
+                    html.H5("Pending Decisions", style={"margin": 0}),
+                    dbc.Button("Random", id="global-random", color="secondary", size="sm")
+                ], style={
+                    "display": "flex",
+                    "justifyContent": "space-between",
+                    "alignItems": "center"
+                })
+            ),
+            dbc.CardBody(
+                html.Div(
+                    id="pending-decisions-body",
+                    style={
+                        "maxHeight": "200px",
+                        "overflowY": "auto",
+                        "padding": "5px"
+                    }
+                )
             )
-        )
-    ], className="mb-3", style={
-        "width": "100%",
-        "minWidth": "300px"
-    })
+        ], className="mb-3", style={
+            "width": "100%",
+            "minWidth": "300px"
+        }),
+        id="pending-decisions-card-container",
+        style={"display": "none"},
+    )
 
 
 def update_pending_decisions(gateway_decisions):


### PR DESCRIPTION
## Summary
- capture the Petri net DOT returned by `get_petri_net`
- include the DOT payload when posting gateway decisions to the simulator

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfdc6fb378832baa4096b8f920ffeb