### PR TITLE
Ensure status info card spans sidebar width

### DIFF
--- a/gui/src/view/home/sidebar/simulator_tab/status_info.py
+++ b/gui/src/view/home/sidebar/simulator_tab/status_info.py
@@ -3,17 +3,20 @@ from dash import html
 
 
 def status_info():
-	return dbc.Card([
-		dbc.CardHeader(html.H5('Status Info')),
-		dbc.CardBody(
-			html.Div(id="status-info-content", style={
-				"maxHeight": "250px",
-				"overflowY": "auto",
-				"overflowX": "hidden",
-				"padding": "0.5rem"
-			})
-		)
-	], className="mb-3", style={"minHeight": "300px"})
+        return dbc.Card([
+                dbc.CardHeader(html.H5('Status Info')),
+                dbc.CardBody(
+                        html.Div(id="status-info-content", style={
+                                "maxHeight": "250px",
+                                "overflowY": "auto",
+                                "overflowX": "hidden",
+                                "padding": "0.5rem"
+                        })
+                )
+        ], className="mb-3", style={
+                "minHeight": "300px",
+                "width": "100%"
+        })
 
 
 def make_table_card(title, dictionary):


### PR DESCRIPTION
## Summary
- set the status info card to use the full width available in the sidebar

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dff734f0e4832bbd5f5c0066551562